### PR TITLE
Moved BrowserSync port option to restore functionality

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -63,8 +63,8 @@ gulp.task('server', function() {
   browsersync({
     server: {
       baseDir: "./build",
-      port: 4000
     },
+    port: 4000,
     notify: false,
     open: false
   });


### PR DESCRIPTION
Gulp server task uses default port of 3000 instead of designated optional port 4000 because "port" in not an option within "server".  Moving the port option out of the server config and into browsersync restores optional port designation.

See:

http://www.browsersync.io/docs/options/#option-port