### PR TITLE
Add Autoprefixer

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,13 +1,15 @@
 var gulp = require('gulp'),
+  autoprefixer = require('gulp-autoprefixer'),
+  bourbon = require('node-bourbon'),
   browsersync = require('browser-sync'),
-  include = require('gulp-include'),
   concat = require('gulp-concat'),
-  haml = require('gulp-ruby-haml'),
-  sass = require('gulp-ruby-sass'),
-  neat = require('node-neat').includePaths,
-  sourcemaps = require('gulp-sourcemaps'),
   coffee = require('gulp-coffee'),
-  deploy = require('gulp-gh-pages');
+  deploy = require('gulp-gh-pages'),
+  haml = require('gulp-ruby-haml'),
+  include = require('gulp-include'),
+  neat = require('node-neat').includePaths,
+  sass = require('gulp-ruby-sass'),
+  sourcemaps = require('gulp-sourcemaps');
 
 var paths = {
   haml: './source/views/*.haml',
@@ -28,8 +30,10 @@ gulp.task('views', function () {
 gulp.task('stylesheets', function() {
   return gulp.src(paths.scss)
     .pipe(sass({
-      loadPath: [paths.scss].concat(neat)
+      loadPath: [paths.scss].concat(neat),
+      "sourcemap=none": true
     }))
+    .pipe(autoprefixer())
     .pipe(gulp.dest('./build/assets/stylesheets'));
 });
 

--- a/package.json
+++ b/package.json
@@ -25,14 +25,16 @@
   "homepage": "http://thoughtbot.github.io/proteus",
   "dependencies": {
     "browser-sync": "~ 1.8.0",
-    "gulp": "~ 3.8.8",
-    "gulp-coffee": "~ 2.2.0",
+    "gulp": "^3.8.11",
+    "gulp-autoprefixer": "^3.0.2",
+    "gulp-coffee": "^2.2.1",
     "gulp-concat": "~ 2.4.1",
     "gulp-gh-pages": "~ 0.4.0",
     "gulp-include": "~ 1.1.0",
     "gulp-ruby-haml": "~0.0.3",
-    "gulp-ruby-sass": "~ 0.7.1",
+    "gulp-ruby-sass": "^0.7.1",
     "gulp-sourcemaps": "~ 1.2.4",
-    "node-neat": "~ 1.3.0"
+    "node-bourbon": "^4.2.3",
+    "node-neat": "^1.7.2"
   }
 }

--- a/source/assets/stylesheets/_global.scss
+++ b/source/assets/stylesheets/_global.scss
@@ -4,9 +4,9 @@ body {
 }
 
 .delete-me {
-  @include align-items(center);
-  @include display(flex);
-  @include justify-content(center);
+  align-items: center;
+  display: flex;
+  justify-content: center;
   height: 100vh;
 
   .container {

--- a/source/assets/stylesheets/base/_buttons.scss
+++ b/source/assets/stylesheets/base/_buttons.scss
@@ -1,6 +1,6 @@
 #{$all-button-inputs},
 button {
-  @include appearance(none);
+  appearance: none;
   -webkit-font-smoothing: antialiased;
   background-color: $action-color;
   border-radius: $base-border-radius;

--- a/source/assets/stylesheets/base/_forms.scss
+++ b/source/assets/stylesheets/base/_forms.scss
@@ -57,7 +57,7 @@ textarea {
 }
 
 input[type="search"] {
-  @include appearance(none);
+  appearance: none;
 }
 
 input[type="checkbox"],


### PR DESCRIPTION
• Adds Autoprefixer to package.json to get ready for Bourbon 5.0
• Disables sourcemaps (it's a bug in how gulp-autoprefixer works. Looks like this is the only solution for now)
• Removes prefixing mixins
